### PR TITLE
Enable gocritic offBy1 and harden Terraform import logging

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
       disable-all: true
       enabled-checks:
         - ruleguard
+        - offBy1
       settings:
         ruleguard:
           failOn: all

--- a/bundle/deploy/terraform/import.go
+++ b/bundle/deploy/terraform/import.go
@@ -70,10 +70,12 @@ func (m *importResource) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	defer os.RemoveAll(tmpDir)
 
 	if changed && !m.opts.AutoApprove {
-		output := buf.String()
-		// Remove output starting from Warning until end of output
-		output = output[:strings.Index(output, "Warning:")]
-		cmdio.LogString(ctx, output)
+                output := buf.String()
+                // Remove output starting from Warning until end of output, if present.
+                if idx := strings.Index(output, "Warning:"); idx != -1 {
+                        output = output[:idx]
+                }
+                cmdio.LogString(ctx, output)
 
 		if !cmdio.IsPromptSupported(ctx) {
 			return diag.Errorf("This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed.")


### PR DESCRIPTION
## Summary
- enable the gocritic offBy1 check in golangci-lint so we catch missing Index() bounds handling
- guard the Terraform import warning truncation against missing "Warning:" blocks to avoid slice panics

## Testing
- go test ./bundle/deploy/terraform -run TestImport -count=1

------
https://chatgpt.com/codex/tasks/task_e_68de961c87008325ac5ddd04e9a8ec94